### PR TITLE
feat: use Listening activity type for Discord presence

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -7,6 +7,10 @@ import (
 	"golang.org/x/net/html"
 )
 
+// Discord activity type for "Listening to ..." presence.
+// go-discordrpc encodes this as 0=Playing, 1=Streaming, 2=Listening, 3=Watching.
+const activityTypeListening = 2
+
 func createActivity(s lfm.Scrobble, songLink bool) client.Activity {
 
 	var songButton *client.Button
@@ -52,6 +56,7 @@ func createActivity(s lfm.Scrobble, songLink bool) client.Activity {
 	}
 
 	return client.Activity{
+		Type:       activityTypeListening,
 		Details:    s.Name,
 		State:      fmt.Sprintf("by %v", s.Artist),
 		LargeImage: coverUrl,


### PR DESCRIPTION
Set RPC activity type 2 so presence renders "Listening to …" instead of "Playing" — Discord lifted the whitelist restriction on this type. `go-discordrpc` exposes no enum, so a local `activityTypeListening` constant is defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Discord presence display to correctly show "Listening to" activity type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/twangodev/lfm-cli/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->