### PR TITLE
Add GoReleaser-based multi-platform distribution

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,8 @@ jobs:
   goreleaser-check:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,7 +70,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
@@ -52,6 +53,7 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,107 +20,59 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build:
+  goreleaser-check:
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-    strategy:
-      matrix:
-        include:
-          # macOS
-          - goos: darwin
-            goarch: amd64
-            name: macos-amd64
-            ext: ""
-          - goos: darwin
-            goarch: arm64
-            name: macos-arm64
-            ext: ""
-          # Windows (arm64 not supported - npipe library lacks ARM64 syscall bindings)
-          - goos: windows
-            goarch: amd64
-            name: windows-amd64
-            ext: ".exe"
-          - goos: windows
-            goarch: 386
-            name: windows-386
-            ext: ".exe"
-          # Linux
-          - goos: linux
-            goarch: amd64
-            name: linux-amd64
-            ext: ""
-          - goos: linux
-            goarch: arm64
-            name: linux-arm64
-            ext: ""
-          - goos: linux
-            goarch: arm
-            name: linux-arm
-            ext: ""
-          - goos: linux
-            goarch: 386
-            name: linux-386
-            ext: ""
-          # FreeBSD
-          - goos: freebsd
-            goarch: amd64
-            name: freebsd-amd64
-            ext: ""
-          - goos: freebsd
-            goarch: arm64
-            name: freebsd-arm64
-            ext: ""
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
 
-      - name: Set binary name
-        # Version comes from the const in main.go, which release-please keeps in
-        # sync; on a release-PR merge it already holds the version being tagged.
-        run: |
-          VERSION=$(sed -n 's/^const version = "\([^"]*\)".*/\1/p' main.go)
-          echo "BINARY_NAME=lfm-cli-${{ matrix.name }}-${VERSION}${{ matrix.ext }}" >> $GITHUB_ENV
+  goreleaser:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # upload release assets
+      id-token: write      # cosign keyless + provenance OIDC
+      attestations: write  # attest-build-provenance
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 
-      - name: Build
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft (SBOM)
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: go build -o "${{ env.BINARY_NAME }}" -v .
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: "${{ env.BINARY_NAME }}"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: lfm-cli-${{ matrix.name }}
-          path: lfm-cli-*
-
-  release:
-    needs: [release-please, build]
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: |
-            artifacts/lfm-cli-*
+          subject-path: "dist/lfm-cli_*"

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ go.work.sum
 # Editor/IDE
 .idea/
 .vscode/
+# GoReleaser output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,7 +73,7 @@ homebrew_casks:
     repository:
       owner: twangodev
       name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"
     directory: Casks
     homepage: "https://github.com/twangodev/lfm-cli"
     description: "Show your Last.FM scrobbles on Discord."
@@ -87,7 +87,7 @@ scoops:
   - repository:
       owner: twangodev
       name: scoop-bucket
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"
     homepage: "https://github.com/twangodev/lfm-cli"
     description: "Show your Last.FM scrobbles on Discord."
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,98 @@
+version: 2
+
+project_name: lfm-cli
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: lfm-cli
+    main: .
+    binary: lfm-cli
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos: [darwin, windows, linux, freebsd]
+    goarch: [amd64, arm64, arm, "386"]
+    goarm: ["7"]
+    ignore:
+      # Windows arm64 unsupported: npipe lacks ARM64 syscall bindings.
+      - { goos: windows, goarch: arm64 }
+      # Keep only the 10 targets the project shipped before.
+      - { goos: darwin, goarch: arm }
+      - { goos: darwin, goarch: "386" }
+      - { goos: windows, goarch: arm }
+      - { goos: freebsd, goarch: arm }
+      - { goos: freebsd, goarch: "386" }
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+    # Must match install.sh: lfm-cli_<version>_<os>_<arch>
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+nfpms:
+  - id: packages
+    package_name: lfm-cli
+    formats: [deb, rpm, apk]
+    maintainer: "James Ding <jamesding365@gmail.com>"
+    description: "Show your Last.FM scrobbles on Discord."
+    homepage: "https://github.com/twangodev/lfm-cli"
+    bindir: /usr/bin
+
+homebrew_casks:
+  - name: lfm-cli
+    repository:
+      owner: twangodev
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/twangodev/lfm-cli"
+    description: "Show your Last.FM scrobbles on Discord."
+    url:
+      verified: "github.com/twangodev/lfm-cli/"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+scoops:
+  - repository:
+      owner: twangodev
+      name: scoop-bucket
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/twangodev/lfm-cli"
+    description: "Show your Last.FM scrobbles on Discord."
+
+release:
+  mode: append          # release-please already created the GitHub Release
+  github:
+    owner: twangodev
+    name: lfm-cli

--- a/README.md
+++ b/README.md
@@ -26,12 +26,36 @@
   <img src=".github/assets/screenshot-2.png">
 </p>
 
-# Usage
+# Getting Started
 
 lfm-cli works right out of the box - no configuration needed.
 
-To get started, download the latest [release](https://github.com/lfm2discord/lfm2discord-cli/releases). These binaries
-are built on GitHub Actions.
+## Installation
+
+**Homebrew (macOS):**
+```console
+brew install twangodev/tap/lfm-cli
+```
+
+**Scoop (Windows):**
+```console
+scoop bucket add twangodev https://github.com/twangodev/scoop-bucket
+scoop install lfm-cli
+```
+
+**Install script (macOS / Linux / FreeBSD):**
+```console
+curl -fsSL https://twango.dev/install/lfm-cli | sh
+```
+
+**Linux packages:** download the `.deb`, `.rpm`, or `.apk` from the
+[latest release](https://github.com/twangodev/lfm-cli/releases/latest).
+
+**Manual:** download the archive for your platform from the
+[releases page](https://github.com/twangodev/lfm-cli/releases). Binaries are
+built and signed (cosign + SBOM) on GitHub Actions.
+
+## Usage
 
 **With [Discord](https://discord.com/) open**, run the following binary in your console
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ curl -fsSL https://twango.dev/install/lfm-cli | sh
 [latest release](https://github.com/twangodev/lfm-cli/releases/latest).
 
 **Manual:** download the archive for your platform from the
-[releases page](https://github.com/twangodev/lfm-cli/releases). Binaries are
-built and signed (cosign + SBOM) on GitHub Actions.
+[releases page](https://github.com/twangodev/lfm-cli/releases). Releases include
+SBOMs and cosign-signed checksums generated on GitHub Actions.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# lfm-cli installer. Usage:
+#   curl -fsSL https://twango.dev/install/lfm-cli | sh
+# Env overrides: VERSION (e.g. v1.5.0), INSTALL_DIR.
+set -eu
+
+REPO="twangodev/lfm-cli"
+BIN="lfm-cli"
+
+err() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+# --- detect OS ---
+os=$(uname -s)
+case "$os" in
+	Darwin) os="darwin" ;;
+	Linux) os="linux" ;;
+	FreeBSD) os="freebsd" ;;
+	MINGW* | MSYS* | CYGWIN* | Windows_NT)
+		err "Windows is not supported by this script. Use Scoop: scoop install lfm-cli" ;;
+	*) err "unsupported OS: $os" ;;
+esac
+
+# --- detect arch (must match GoReleaser archive names) ---
+arch=$(uname -m)
+case "$arch" in
+	x86_64 | amd64) arch="amd64" ;;
+	arm64 | aarch64) arch="arm64" ;;
+	armv7l | armv6l | arm) arch="arm" ;;
+	i386 | i686) arch="386" ;;
+	*) err "unsupported architecture: $arch" ;;
+esac
+
+# --- resolve version ---
+version="${VERSION:-}"
+if [ -z "$version" ]; then
+	version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+		grep '"tag_name"' | head -n1 | cut -d'"' -f4)
+fi
+[ -n "$version" ] || err "could not resolve latest release version"
+
+# --- download + verify ---
+archive="${BIN}_${version#v}_${os}_${arch}.tar.gz"
+base="https://github.com/${REPO}/releases/download/${version}"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+printf 'Downloading %s %s (%s/%s)...\n' "$BIN" "$version" "$os" "$arch"
+curl -fsSL "${base}/${archive}" -o "${tmp}/${archive}" ||
+	err "download failed: ${base}/${archive}"
+curl -fsSL "${base}/checksums.txt" -o "${tmp}/checksums.txt" ||
+	err "checksums download failed"
+
+# verify SHA256 (sha256sum on Linux, shasum on macOS/BSD)
+expected=$(grep " ${archive}\$" "${tmp}/checksums.txt" | cut -d' ' -f1)
+[ -n "$expected" ] || err "no checksum entry for ${archive}"
+if command -v sha256sum >/dev/null 2>&1; then
+	actual=$(sha256sum "${tmp}/${archive}" | cut -d' ' -f1)
+else
+	actual=$(shasum -a 256 "${tmp}/${archive}" | cut -d' ' -f1)
+fi
+[ "$expected" = "$actual" ] || err "checksum mismatch for ${archive}"
+
+# --- extract + install ---
+tar -xzf "${tmp}/${archive}" -C "$tmp"
+[ -f "${tmp}/${BIN}" ] || err "binary ${BIN} not found in archive"
+
+dir="${INSTALL_DIR:-}"
+if [ -z "$dir" ]; then
+	if [ -w /usr/local/bin ] 2>/dev/null; then dir="/usr/local/bin"; else dir="${HOME}/.local/bin"; fi
+fi
+mkdir -p "$dir"
+install -m 0755 "${tmp}/${BIN}" "${dir}/${BIN}"
+
+printf 'Installed %s to %s/%s\n' "$BIN" "$dir" "$BIN"
+case ":${PATH}:" in
+	*":${dir}:"*) ;;
+	*) printf "Note: %s is not on your PATH. Add it:\n  export PATH=\"%s:\$PATH\"\n" "$dir" "$dir" ;;
+esac
+"${dir}/${BIN}" --version || true

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ arch=$(uname -m)
 case "$arch" in
 	x86_64 | amd64) arch="amd64" ;;
 	arm64 | aarch64) arch="arm64" ;;
-	armv7l | armv6l | arm) arch="arm" ;;
+	armv7l | arm) arch="arm" ;;
+	armv6l) err "ARMv6 is not supported by current releases (built for ARMv7+)" ;;
 	i386 | i686) arch="386" ;;
 	*) err "unsupported architecture: $arch" ;;
 esac


### PR DESCRIPTION
Replaces the hand-rolled build/release matrix with GoReleaser: produces archives, checksums, SBOMs, cosign signatures, deb/rpm/apk packages, a Homebrew cask, and a Scoop manifest, and adds a version-agnostic `install.sh` for `curl | sh` installs. Keeps the existing release-please flow (`release.mode: append`) and build-provenance attestation.

Requires repo secret `TAP_GITHUB_TOKEN` (PAT with contents:write on homebrew-tap + scoop-bucket) and a `twangodev/scoop-bucket` repo before the next tagged release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple installation methods: Homebrew (macOS), Scoop (Windows), and universal install script for macOS/Linux/FreeBSD.
  * Binaries now include cryptographic signatures and checksums for verification.

* **Documentation**
  * Updated getting started guide with comprehensive installation instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/twangodev/lfm-cli/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->