### PR TITLE
Drop trailing period from package descriptions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,7 +64,7 @@ nfpms:
     package_name: lfm-cli
     formats: [deb, rpm, apk]
     maintainer: "James Ding <jamesding365@gmail.com>"
-    description: "Show your Last.FM scrobbles on Discord."
+    description: "Show your Last.FM scrobbles on Discord"
     homepage: "https://github.com/twangodev/lfm-cli"
     bindir: /usr/bin
 
@@ -76,7 +76,7 @@ homebrew_casks:
       token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"
     directory: Casks
     homepage: "https://github.com/twangodev/lfm-cli"
-    description: "Show your Last.FM scrobbles on Discord."
+    description: "Show your Last.FM scrobbles on Discord"
     url:
       verified: "github.com/twangodev/lfm-cli/"
     commit_author:
@@ -89,7 +89,7 @@ scoops:
       name: scoop-bucket
       token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"
     homepage: "https://github.com/twangodev/lfm-cli"
-    description: "Show your Last.FM scrobbles on Discord."
+    description: "Show your Last.FM scrobbles on Discord"
 
 release:
   mode: append          # release-please already created the GitHub Release


### PR DESCRIPTION
Homebrew's `brew audit` flags `Cask/Desc` when a cask description ends with a period. Removes the trailing `.` from the cask/scoop/nfpm descriptions so the generated cask is audit-clean. Takes effect on the next release.