### PR TITLE
chore: update maintainer email to james@twango.dev

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ nfpms:
   - id: packages
     package_name: lfm-cli
     formats: [deb, rpm, apk]
-    maintainer: "James Ding <jamesding365@gmail.com>"
+    maintainer: "James Ding <james@twango.dev>"
     description: "Show your Last.FM scrobbles on Discord"
     homepage: "https://github.com/twangodev/lfm-cli"
     bindir: /usr/bin

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-jamesding365@gmail.com.
+james@twango.dev.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		Authors: []*cli.Author{
 			{
 				Name:  "James Ding",
-				Email: "jamesding365@gmail.com",
+				Email: "james@twango.dev",
 			},
 		},
 		Copyright: "(c) 2022 James Ding",


### PR DESCRIPTION
Updates the maintainer/contact email to `james@twango.dev` across the CLI metadata, goreleaser config, and code of conduct.